### PR TITLE
msm8226: fix typo from "hwc: Validate display ID in hwc interfaces"

### DIFF
--- a/msm8226/libhwcomposer/hwc.cpp
+++ b/msm8226/libhwcomposer/hwc.cpp
@@ -746,7 +746,7 @@ int hwc_getDisplayConfigs(struct hwc_composer_device_1* dev, int disp,
     int ret = 0;
     hwc_context_t* ctx = (hwc_context_t*)(dev);
 
-    if (!validDisplay(dpy)) {
+    if (!validDisplay(disp)) {
         return -EINVAL;
     }
     disp = getDpyforExternalDisplay(ctx, disp);
@@ -780,7 +780,7 @@ int hwc_getDisplayAttributes(struct hwc_composer_device_1* dev, int disp,
 
     hwc_context_t* ctx = (hwc_context_t*)(dev);
 
-    if (!validDisplay(dpy)) {
+    if (!validDisplay(disp)) {
         return -EINVAL;
     }
     disp = getDpyforExternalDisplay(ctx, disp);


### PR DESCRIPTION
validDisplay checks were added to each HAL, but in msm8226 the wrong
check was copied twice.

https://github.com/CyanogenMod/android_hardware_qcom_display/commit/b3d80f10d0f78d404f75b7c57a0b17e985c9b813

Change-Id: I41230c238e2c96ecff148aa5fadc49f431212cf0
Signed-off-by: Adam Farden <adam@farden.cz>